### PR TITLE
Rough draft of formatDuration with new "long" format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwgps/units",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Unit conversion and formatting",
   "main": "src/index.js",
   "dependencies": {},

--- a/scratch.js
+++ b/scratch.js
@@ -1,0 +1,28 @@
+// usage: npx nodemon scratch.js
+
+require('babel-core/register')
+const {formatDuration} = require('./src')
+
+const example = (ex) => {
+  console.log(`$ ${ex}`)
+  console.log(`=> ${eval(ex)}`)
+  console.log()
+}
+
+example('formatDuration(60).toString({short: true})')
+
+example('formatDuration(60)')
+
+example('formatDuration(60).valueToString()')
+
+example('formatDuration(60).short')
+
+example('formatDuration(60).long')
+
+example('formatDuration(87, {includeSeconds: true})')
+
+example('formatDuration(87, {includeSeconds: true}).toString({short: true})')
+
+example('formatDuration(87, {includeSeconds: true}).short')
+example('formatDuration(87, {includeSeconds: true}).long')
+

--- a/src/conversions.js
+++ b/src/conversions.js
@@ -25,7 +25,7 @@ export const feetToFeet = (ft) => ft
 
 export const feetToMeters = (ft) => ft * C.METERS_IN_FOOT
 
-export const feetToMiles = (ft) => ft / C.FEET_IN_MILES
+export const feetToMiles = (ft) => ft / C.FEET_IN_MILE
 
 export const feetToKm = (ft) => ft * C.METERS_IN_FOOT / C.METERS_IN_KM
 
@@ -36,7 +36,7 @@ export const milesToMeters = (m) => m * C.METERS_IN_MILE
 
 export const milesToKm = (m) => m * C.METERS_IN_MILE / C.METERS_IN_KM
 
-export const milesToFeet = (m) => m * C.FEET_IN_MILES
+export const milesToFeet = (m) => m * C.FEET_IN_MILE
 
 // % (grade)
 export const gradeToGrade = (p) => p

--- a/src/formatDuration.js
+++ b/src/formatDuration.js
@@ -1,8 +1,5 @@
-// TODO
-import * as C from './constants'
-import {convert} from './conversions'
 import * as unitTypes from './unitTypes'
 
 export const formatDuration = (seconds, opts) => {
-  return unitTypes.hourMinuteSecond(seconds, opts)
+  return unitTypes.duration(seconds, opts)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,5 +21,8 @@ export {formatDuration}
 import {formatPace} from './formatPace'
 export {formatPace}
 
+import {formatPower} from './formatPower'
+export {formatPower}
+
 import * as constants from './constants'
 export {constants}


### PR DESCRIPTION
A bit of a disclaimer - this codebase is beginning to show its age/limitations.

In particular, the assumptions this library makes around unit placement, labeling, etc, break down when you're trying to produce human-readable duration formats. It turns out there isn't as clean of a separation between unit conversion and unit formatting as a person might want.

For now, this _works_. In the future, I think it would be worthwhile to consider refactoring/re-architecting this library to better fit our needs.